### PR TITLE
Feat/78 login proviers

### DIFF
--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -1,4 +1,5 @@
 import { LoginRequestDto } from "@/application/usecases/auth/dtos/LoginRequestDto";
+import { LoginResponseDto } from "@/application/usecases/auth/dtos/LoginResponseDto";
 import { LoginError, LoginErrorType } from "@/application/usecases/auth/errors/LoginError";
 import { IPasswordHasherUseCase } from "@/application/usecases/auth/interfaces/IPasswordHasherUseCase";
 import { LoginUseCase } from "@/application/usecases/auth/LoginUseCase";
@@ -24,13 +25,14 @@ export async function POST(req: NextRequest) {
     const loginUseCase = new LoginUseCase(userRepository, passwordHasherUseCase);
     
     // 로그인 기능 실행
-    const userId = await loginUseCase.execute(request);
-    console.log(userId)
+    const loginResponseDto :LoginResponseDto = await loginUseCase.execute(request);
+    
+    // responseDto 데이터 연결 확인
+    console.log(loginResponseDto)
     
     // 로그인 성공 시 전달 메시지;
-    return NextResponse.json({userId}, {status:200});
+    return NextResponse.json(loginResponseDto, {status:200});
 
-  
     // 로그인 실패 시 전달 메시지
 } catch (error) {
     console.error("❌ 로그인 오류", error);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,9 @@ import "../styles/global.css";
 import LayoutContainer from "../components/common/LayoutContainer";
 import StyledComponentsRegistry from "@/lib/registry";
 
+// 관리자 접근제한
+// import ProtectedRoute from "@/components/common/ProtectedRoute";
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const isAdminPage = pathname.startsWith("/admin"); 
@@ -16,7 +19,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         {!isAdminPage ? (
           <LayoutContainer>{children}</LayoutContainer>
         ) : (
-          children 
+          children
+          // <ProtectedRoute adminOnly>{children}</ProtectedRoute>
         )}
         </StyledComponentsRegistry>
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import {
   TextContainer,
   SubTitleText,
@@ -9,9 +10,31 @@ import {
   Title,
   ButtonWrapper,
 } from "./Home.Styled";
-import Link from "next/link";
-import  Button  from "@/components/common/button/Button";
+import Button from "@/components/common/button/Button";
+import { autoLogin } from "@/utils/auth/autoLogin";
+import useAuthStore from "@/store/authStore";
+import { useRouter } from "next/navigation";
 const Home = () => {
+  const { isAuthenticated, isAdmin } = useAuthStore();
+  const [routerAddress, setRouterAddress] = useState<string>("/login");
+
+  const router = useRouter();
+  
+  useEffect(() => {
+    autoLogin();
+
+    if (!isAuthenticated) {
+      setRouterAddress("/login");
+      return ;
+    } else {
+      setRouterAddress(isAdmin ? "/admin": "/profile");
+    }
+  }, [isAuthenticated, isAdmin]);
+
+  const handleClickStart = () => {
+    router.push(routerAddress);
+  };
+
   return (
     <>
       <TextContainer>
@@ -25,13 +48,11 @@ const Home = () => {
         <img src="/Images/logo.svg" alt="로고" />
       </IconContainer>
       <Title>소톡소톡</Title>
-      <Link href="/login">
-        <ButtonWrapper>
-          <Button size="m" variant="contained">
-            시작하기
-          </Button>
-        </ButtonWrapper>
-      </Link>
+      <ButtonWrapper>
+        <Button size="m" variant="contained" onClick={handleClickStart}>
+          시작하기
+        </Button>
+      </ButtonWrapper>
     </>
   );
 };

--- a/src/application/usecases/auth/LoginUseCase.ts
+++ b/src/application/usecases/auth/LoginUseCase.ts
@@ -2,6 +2,7 @@ import { IUserRepository } from "@/domain/repositories/auth/IUserRepository";
 import { LoginRequestDto } from "@/application/usecases/auth/dtos/LoginRequestDto";
 import { IPasswordHasherUseCase } from '@/application/usecases/auth/interfaces/IPasswordHasherUseCase';
 import { LoginError } from "@/application/usecases/auth/errors/LoginError";
+import { LoginResponseDto } from "@/application/usecases/auth/dtos/LoginResponseDto";
 
 export class LoginUseCase {
     constructor(
@@ -9,9 +10,8 @@ export class LoginUseCase {
       private readonly passwordHasherUseCase: IPasswordHasherUseCase,
     ) {}
   
-    async execute(request: LoginRequestDto): Promise<string> {
+    async execute(request: LoginRequestDto): Promise<LoginResponseDto> {
       console.log("LoginUseCase mounted");
-      console.log(request.email, request.password);
 
       if (!request.email?.trim() || !request.password?.trim()) {
         throw new LoginError("MISSING_CREDENTIALS","이메일과 비밀번호를 모두 입력해주세요.")
@@ -24,8 +24,7 @@ export class LoginUseCase {
         throw new LoginError("EMAIL_NOT_FOUND", "가입되지 않은 이메일입니다.");
       }
 
-      const { userId, password} =userWithPassword;
-  
+      const { userId, password, role} =userWithPassword;
       // 3. 비밀번호 비교
       const isValidPassword: boolean = await this.passwordHasherUseCase.compare(request.password, password);
       
@@ -34,7 +33,7 @@ export class LoginUseCase {
         throw new LoginError("INVALID_PASSWORD", "비밀번호가 올바르지 않습니다.");
       }
 
-      return userId;
+      return {userId, role};
     }
     
 }

--- a/src/application/usecases/auth/dtos/LoginResponseDto.ts
+++ b/src/application/usecases/auth/dtos/LoginResponseDto.ts
@@ -1,0 +1,6 @@
+import { UserRole } from "@/types/auth";
+
+export interface LoginResponseDto {
+    userId: string;
+    role: UserRole;
+}

--- a/src/application/usecases/auth/dtos/UserResponseDto.ts
+++ b/src/application/usecases/auth/dtos/UserResponseDto.ts
@@ -4,6 +4,7 @@ export interface UserResponseDto {
     name: string;
     birthDate: string;
     phone: string;
+    role: string;
     createdAt: Date;
     updatedAt: Date;
 }

--- a/src/components/common/ProtectedRoute.tsx
+++ b/src/components/common/ProtectedRoute.tsx
@@ -1,0 +1,27 @@
+import useAuthStore from "@/store/authStore";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+interface ProtectedRouteProps {
+    children: React.ReactNode;
+    adminOnly?: boolean;
+}
+
+const ProtectedRoute = ({children, adminOnly= false}: ProtectedRouteProps) => {
+
+    const {isAuthenticated, isAdmin} = useAuthStore();
+    const router = useRouter();
+
+    useEffect(()=>{
+        if(!isAuthenticated) {
+            alert("로그인을 해주세요")
+            router.push("/login");
+        } else if(adminOnly && !isAdmin){
+            alert("관리자만 접근 가능합니다.");
+            router.push("/profile")
+        }
+    }, [isAuthenticated, isAdmin, router, adminOnly]);
+
+    return <>{children}</>
+}
+export default ProtectedRoute

--- a/src/domain/entities/user/User.ts
+++ b/src/domain/entities/user/User.ts
@@ -1,3 +1,5 @@
+import { UserRole } from "@/types/auth";
+
 export interface User {
     userId: string;
     email: string;
@@ -7,4 +9,5 @@ export interface User {
     phone: string;
     createdAt?: Date;
     updatedAt?: Date;
+    role?: UserRole;
 }

--- a/src/domain/repositories/auth/IUserRepository.ts
+++ b/src/domain/repositories/auth/IUserRepository.ts
@@ -1,9 +1,10 @@
 import { User } from "@/domain/entities/user/User";
+import { UserRole } from "@/types/auth";
 
 export interface IUserRepository {
     createUser (user: User): Promise<void>;
     // 지워야할 것이지만 conflict 때문에 냄겨둠
     findByEmail (email: string): Promise<User | null>;
     findUserById(userId: string): Promise<{password: string; user: Omit<User, "password"> } | null>;
-    findAuthDataByEmail(email: string): Promise<{ userId: string; password: string } | null>;
+    findAuthDataByEmail(email: string): Promise<{ userId: string; password: string; role:UserRole;} | null>;
 }

--- a/src/infrastructure/repositories/auth/SbUserRepository.ts
+++ b/src/infrastructure/repositories/auth/SbUserRepository.ts
@@ -2,6 +2,7 @@ import supabase from "@/infrastructure/databases/supabase/server";
 import { User } from "@/domain/entities/user/User";
 import { IUserRepository } from "@/domain/repositories/auth/IUserRepository";
 import { toCamelCase, toSnakeCase } from '@/utils/convert/convertToCase';
+import { UserRole } from "@/types/auth";
 
 export class SbUserRepository implements IUserRepository {
   private readonly tableName = "user";
@@ -67,13 +68,13 @@ export class SbUserRepository implements IUserRepository {
     return { password, user };
   }
   // email을 통한 userId, password 가져오기
-  async findAuthDataByEmail(email: string): Promise<{ userId: string; password: string } | null> {
+  async findAuthDataByEmail(email: string): Promise<{ userId: string; password: string; role: UserRole } | null> {
     console.log("repository mounted")
     const client = await supabase();
 
     const { data, error } = await client
       .from(this.tableName)
-      .select("user_id, password")
+      .select("user_id, password , role")
       .eq("email", email)
       .single();
 
@@ -85,6 +86,6 @@ export class SbUserRepository implements IUserRepository {
       console.error("Error finding password:", error.message);
       throw new Error("EMAIL_NOT_FOUND");
     }
-    return { userId: data.user_id , password: data.password } ;
+    return { userId: data.user_id , password: data.password, role: data.role } ;
   }
 }

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,0 +1,34 @@
+import { UserRole } from "@/types/auth";
+import { create } from "zustand";
+
+interface AuthState {
+  userId: string | null;
+  role: UserRole | null;
+  isAuthenticated: boolean;
+  isAdmin: boolean;
+  setAuth: (userId: string, role: UserRole) => void;
+  clearAuth: () => void;
+}
+
+const useAuthStore = create<AuthState>((set) => ({
+  userId: null,
+  role: null,
+  isAuthenticated: false,
+  isAdmin: false,
+  setAuth: (userId, role) =>
+    set({ 
+        userId, 
+        role, 
+        isAuthenticated: true, 
+        isAdmin: role === "admin" 
+    }),
+  clearAuth: () => 
+    set({ 
+        userId: null, 
+        role: null, 
+        isAuthenticated: false,
+        isAdmin: false, 
+    }),
+}));
+
+export default useAuthStore;

--- a/src/types/auth.d.ts
+++ b/src/types/auth.d.ts
@@ -1,0 +1,1 @@
+export type UserRole = "user" | "admin";

--- a/src/utils/auth/autoLogin.ts
+++ b/src/utils/auth/autoLogin.ts
@@ -1,0 +1,13 @@
+import useAuthStore from "@/store/authStore";
+import { UserRole } from "@/types/auth";
+
+export const autoLogin = () => {
+    const { setAuth } = useAuthStore.getState();
+
+    const storedUserId = localStorage.getItem('userId');
+    const storedRole = localStorage.getItem('role')as UserRole | null;
+
+    if(storedUserId && storedRole) {
+        setAuth(storedUserId, storedRole);
+    }
+}


### PR DESCRIPTION
## 🔘Part

- [x] FE

  <br/>

## 🔎 로그인 성공 시 zustand를 통해 전역 상태 관리 local Storage저장소 활용
1. Role DB 및 BE 출력 로직 작성
2. 로그인 성공 시 상태 관리 
3. 로컬스토리지에서 값을 가져와 자동 로그인 상태 등록
4. protected Route를 통한 관리자 페이지 접근제한 
  <br/>

## 이미지 첨부

<br/>

## 🔧 앞으로의 과제
signup Result 페이지 ui 구현
mypageUI구현
id찾기 페이지UI구현

  <br/>

## ➕ 이슈 링크

- [obama #78 ]

<br/>
